### PR TITLE
Thai/limit response size

### DIFF
--- a/dark-debris/package-lock.json
+++ b/dark-debris/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/react": "^3.0.10",
+        "@azure/msal-browser": "^3.11.1",
+        "@azure/msal-react": "^2.0.14",
         "@azure/openai": "^1.0.0-beta.12",
         "@google/generative-ai": "^0.2.1",
         "@types/react": "^18.2.57",
@@ -228,6 +230,37 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-3.13.0.tgz",
+      "integrity": "sha512-fD906nmJei3yE7la6DZTdUtXKvpwzJURkfsiz9747Icv4pit77cegSm6prJTKLQ1fw4iiZzrrWwxnhMLrTf5gQ==",
+      "dependencies": {
+        "@azure/msal-common": "14.9.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.9.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.9.0.tgz",
+      "integrity": "sha512-yzBPRlWPnTBeixxLNI3BBIgF5/bHpbhoRVuuDBnYjCyWRavaPUsKAHUDYLqpGkBLDciA6TCc6GOxN4/S3WiSxg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-react": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-2.0.15.tgz",
+      "integrity": "sha512-WtZGPxA6rWqGhovmWPUXjUyKTp/TUa4Oekk6FSa9ldCayd1QzYT9XcoAEqA0EfT0Fx12KiNvJyDDKckBU6J/+Q==",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@azure/msal-browser": "^3.13.0",
+        "react": "^16.8.0 || ^17 || ^18"
       }
     },
     "node_modules/@azure/openai": {

--- a/dark-debris/src/CSS/FileUpload.css
+++ b/dark-debris/src/CSS/FileUpload.css
@@ -17,3 +17,7 @@
     object-fit: contain;
     width: 95%;
 }
+
+#advanced-options summary {
+    border: none;
+}

--- a/dark-debris/src/components/FileUpload.astro
+++ b/dark-debris/src/components/FileUpload.astro
@@ -5,7 +5,7 @@
 				<label for="file-input"><h3>File</h3></label>
 				<input type="file" id="file-input" accept=".png,.jpg,.jpeg,.webp" />
 
-				<!-- <details id="advanced-options">
+				<details id="advanced-options">
 					<summary>Advanced Options</summary>
 					<div class="checkbox">
 						<input
@@ -16,15 +16,7 @@
 						/><label for="limit-response"
 							>Limit responses to under 260 characters.</label>
 					</div>
-				</details> -->
-				<input
-					type="checkbox"
-					id="limit-response"
-					name="limit"
-					value="First"
-				/><label for="limit-response"
-					>Limit responses to under 260 characters.</label
-				>
+				</details>
 			</form>
 
 			<button id="evaluate-image">Evaluate Image</button>

--- a/dark-debris/src/components/FileUpload.astro
+++ b/dark-debris/src/components/FileUpload.astro
@@ -4,6 +4,19 @@
 			<form id="file-upload-form">
 				<label for="file-input"><h3>File</h3></label>
 				<input type="file" id="file-input" accept=".png,.jpg,.jpeg,.webp" />
+				
+				<details id="advanced-options">
+					<summary>Advanced Options</summary>
+					<div class="checkbox">
+						<input
+							type="checkbox"
+							id="limit-response"
+							name="limit"
+							value="First"
+						/><label for="limit-response"
+							>Limit responses to under 260 characters.</label>
+					</div>
+				</details>
 			</form>
 
 			<button id="evaluate-image">Evaluate Image</button>
@@ -25,4 +38,3 @@
 <script src="../js/UploadHelper.js"></script>
 
 <!-- "Requests to the ChatCompletions_Create Operation under Azure OpenAI API version 2024-03-01-preview have exceeded call rate limit of your current OpenAI S0 pricing tier. Please retry after 18 seconds. Please go here: https://aka.ms/oai/quotaincrease if you would like to further increase the default rate limit." -->
-

--- a/dark-debris/src/components/FileUpload.astro
+++ b/dark-debris/src/components/FileUpload.astro
@@ -4,8 +4,8 @@
 			<form id="file-upload-form">
 				<label for="file-input"><h3>File</h3></label>
 				<input type="file" id="file-input" accept=".png,.jpg,.jpeg,.webp" />
-				
-				<details id="advanced-options">
+
+				<!-- <details id="advanced-options">
 					<summary>Advanced Options</summary>
 					<div class="checkbox">
 						<input
@@ -16,7 +16,15 @@
 						/><label for="limit-response"
 							>Limit responses to under 260 characters.</label>
 					</div>
-				</details>
+				</details> -->
+				<input
+					type="checkbox"
+					id="limit-response"
+					name="limit"
+					value="First"
+				/><label for="limit-response"
+					>Limit responses to under 260 characters.</label
+				>
 			</form>
 
 			<button id="evaluate-image">Evaluate Image</button>

--- a/dark-debris/src/js/API.js
+++ b/dark-debris/src/js/API.js
@@ -2,6 +2,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 import { OpenAIClient, AzureKeyCredential } from "@azure/openai"
 import OpenAI from "openai";
 
+var limit_response = document.getElementById("limit-response").checked
 
 const showErrorDialog = (msg) => {
   const dialog = document.getElementById("evaluate-error")
@@ -54,15 +55,12 @@ const handleGeminiCall = async () => {
   if (dataURL !== "data:,") {
     const genAI = new GoogleGenerativeAI(import.meta.env.PUBLIC_GEMINI_KEY);
     const model = genAI.getGenerativeModel({ model: "gemini-pro-vision" });
-
-    // const promptFieldValue = document.getElementById("prompt").value
-    const promptFieldValue = ""
-
+    var limit_response = document.getElementById("limit-response").checked
+    
     let prompt = "Compose a detailed description in English for this image.";
-    if (promptFieldValue !== "") {
-      prompt = prompt + " This is additional information from the user: " + promptFieldValue;
+    if (limit_response) {
+      prompt += " Limit the response to under 260 characters."
     }
-
     console.log(prompt)
 
     const payload = {
@@ -197,6 +195,11 @@ const handleGeminiURL = async () => {
 
     const promptFieldValue = document.getElementById("prompt").value;
     let prompt = "Compose a detailed description in English for this image.";
+
+    if (limit_response) {
+      prompt += " Limit the response to under 260 characters."
+    }
+
     if (promptFieldValue !== "") {
       prompt += " This is additional information from the user: " + promptFieldValue;
     }
@@ -279,6 +282,7 @@ const handleGeminiURL = async () => {
 // }
 
 const handleOpenAICall = async () => {
+  var limit_response = document.getElementById("limit-response").checked
   const openai = new OpenAI({
     apiKey: import.meta.env.PUBLIC_CHATGPT_KEY,
     dangerouslyAllowBrowser: true
@@ -286,6 +290,11 @@ const handleOpenAICall = async () => {
   const canvas = document.getElementById("canvas");
 
   const dataURL = canvas.toDataURL("image/jpeg", 0.5);
+
+  let prompt = "Give a descriptive alternative text for the image.";
+  if (limit_response) {
+    prompt += " Limit the response to under 260 characters."
+  }
 
   if (dataURL !== "data:,") {
     try {
@@ -301,7 +310,7 @@ const handleOpenAICall = async () => {
             }, 
             {
               type: "text",
-              text: "Give a descriptive alternative text for the image."
+              text: prompt
             }
           ]
         }],

--- a/dark-debris/src/js/UploadHelper.js
+++ b/dark-debris/src/js/UploadHelper.js
@@ -20,6 +20,7 @@ file_button.addEventListener("click", async () => {
     });
 
     document.getElementById("results-section").scrollIntoView();
+
   } catch (error) {
     console.error(error);
   } finally {


### PR DESCRIPTION
Added an advanced options dropdown that contains a checkbox that will limit the responses of GPT and OpenAI to under 260 characters. There may be other advanced options that we may want to consider later and it can go under this dropdown.