### PR TITLE
changed from innerHTML to textContent for snyk fixes

### DIFF
--- a/dark-debris/src/js/ModalHelper.js
+++ b/dark-debris/src/js/ModalHelper.js
@@ -5,7 +5,7 @@
 const showErrorDialog = (msg) => {
 	const dialog = document.getElementById("evaluate-error");
 	const message = document.getElementById("evaluate-error-message");
-	message.innerHTML = msg;
+	message.textContent = msg;
 	dialog.showModal();
 };
 

--- a/dark-debris/src/js/authHelper.js
+++ b/dark-debris/src/js/authHelper.js
@@ -23,4 +23,4 @@ document.getElementById("getUserInfo").addEventListener("click", async () => {
 	return AuthHelper.getUsername();
 });*/
 
-document.getElementById("username").innerHTML = await AuthHelper.getUsername();
+document.getElementById("username").textContent = await AuthHelper.getUsername();


### PR DESCRIPTION
Prevent xss by swapping innerHTML to textContent so all user provided text is html is encoded